### PR TITLE
Measurement date input

### DIFF
--- a/packages/frontend/src/creation-form/i18n/en.json
+++ b/packages/frontend/src/creation-form/i18n/en.json
@@ -15,6 +15,8 @@
     "error.value1.ranged.tooLow": "Value can't be lower than lower bound",
     "error.values.ranged.between.sameValues": "Values can't be the same with the selected constraint",
     "error.ranged.zero": "Value can't be 0",
+    "error.timestamp.invalid": "Value not valid",
+    "error.maximum.date.past": "Expiration date too near in the future, choose a date that falls after {{minimumDate}}.",
     "label.goal.summary.single": "The goal will be considered reached if the metric measured at the measurement timestamp",
     "placeholder.value0.single": "Pick a value",
     "label.value0.ranged": "Lower bound",


### PR DESCRIPTION
Disable the measurement date time input and display and error if the maximum available date to pick is in the past.

The issue is caused by picking an `expiration` date (step 1), too near in the future (before the current time + `expirationBufferTime` configured on the oracle), thus causing the maximum date in the input to be in the past, since:

```tsx
const maximumDate = dayjs.unix(kpiToken.expiration).subtract(Number(expirationBufferTime), "seconds")
```